### PR TITLE
[FEAT] 장소(Place) 관련 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Dockerfile ###
+Dockerfile

--- a/src/main/java/com/plac/common/Constant.java
+++ b/src/main/java/com/plac/common/Constant.java
@@ -20,4 +20,9 @@ public interface Constant {
             "/api/**",
             "/api/test/**",
     };
+
+    String[] PLACE_REVIEW_TAGS = new String[]{
+            "혼자", "친구", "연인", "아이", "부모님", "반려동물",
+            "데이트", "SNS 핫플레이스", "힐링", "먹방", "가성비", "분위기", "혼자놀기"
+    };
 }

--- a/src/main/java/com/plac/common/Constant.java
+++ b/src/main/java/com/plac/common/Constant.java
@@ -6,6 +6,8 @@ public interface Constant {
 
     String[] ALL_PERMIT_PATHS = new String[]{
             "/api/users/one",
+            "/api/places",
+            "/api/places/**",
             "/api/users/emails/availability",
             "/api/login/**",
             "/api/social-login",

--- a/src/main/java/com/plac/controller/EmailController.java
+++ b/src/main/java/com/plac/controller/EmailController.java
@@ -4,6 +4,7 @@ import com.plac.dto.request.email.EmailReqDto;
 import com.plac.dto.request.email.EmailVerifyReqDto;
 import com.plac.service.email.EmailVerificationService;
 import com.plac.service.user.UserService;
+import com.plac.util.MessageUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,24 +24,25 @@ public class EmailController {
     private final UserService userService;
 
     @PostMapping("/send-verification-email")
-    public ResponseEntity<Void> sendVerificationEmail(
+    public ResponseEntity<?> sendVerificationEmail(
             @Valid @RequestBody EmailReqDto dto
     ) {
         String inputEmail = dto.getEmail();
+        System.out.println(inputEmail);
 
         userService.checkEmailAvailability(inputEmail);
 
         emailVerificationService.sendSignupVerificationEmail(inputEmail);
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
     }
 
     @PostMapping("/verify-code")
-    public ResponseEntity<Void> verifyEmailVerificationCode(
+    public ResponseEntity<?> verifyEmailVerificationCode(
             @Valid @RequestBody EmailVerifyReqDto dto
     ) {
         emailVerificationService.verifySignupEmail(dto.getEmail(), dto.getCode());
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
     }
 }

--- a/src/main/java/com/plac/controller/PlaceController.java
+++ b/src/main/java/com/plac/controller/PlaceController.java
@@ -1,0 +1,31 @@
+package com.plac.controller;
+
+import com.plac.dto.request.place.PlaceReqDto;
+import com.plac.dto.request.user.UserReqDto;
+import com.plac.dto.response.place.PlaceResDto;
+import com.plac.service.place.PlaceService;
+import com.plac.util.MessageUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/places")
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @PostMapping("")
+    public ResponseEntity<?> searchPlaceSummaryInfo(@RequestBody PlaceReqDto req) throws Exception {
+        List<PlaceResDto> placeSummaryInfo = placeService.getPlaceSummaryInfo(req);
+
+        return MessageUtil.buildResponseEntity(placeSummaryInfo, HttpStatus.OK, "success");
+    }
+}

--- a/src/main/java/com/plac/controller/PlaceController.java
+++ b/src/main/java/com/plac/controller/PlaceController.java
@@ -1,6 +1,8 @@
 package com.plac.controller;
 
+import com.plac.dto.request.place.PlaceDetailsReqDto;
 import com.plac.dto.request.place.PlaceReqDto;
+import com.plac.dto.response.place.PlaceDetailsResDto;
 import com.plac.dto.response.place.PlaceResDto;
 import com.plac.service.place.PlaceService;
 import com.plac.util.MessageUtil;
@@ -25,12 +27,11 @@ public class PlaceController {
         return MessageUtil.buildResponseEntity(placeSummaryInfo, HttpStatus.OK, "success");
     }
 
-//    @GetMapping("/details")
-//    public ResponseEntity<?> searchPlaceDetails(@RequestParam("kakaoPlaceId") Long kakaoPlaceId,
-//                                             @RequestParam("sortBy") String sort,
-//                                             @RequestParam("page") int page) throws Exception {
-//
-//       placeService.getPlacesDetails(kakaoPlaceId, sort, page);
-//
-//    }
+    @GetMapping("/detail")
+    public ResponseEntity<?> searchPlaceDetails( @RequestParam("placeId") Long placeId) throws Exception {
+        PlaceDetailsResDto placeDetails = placeService.getPlaceDetails(placeId);
+
+        return MessageUtil.buildResponseEntity(placeDetails, HttpStatus.OK, "success");
+    }
+
 }

--- a/src/main/java/com/plac/controller/PlaceController.java
+++ b/src/main/java/com/plac/controller/PlaceController.java
@@ -19,16 +19,18 @@ public class PlaceController {
     private final PlaceService placeService;
 
     @PostMapping("")
-    public ResponseEntity<?> searchPlaceSummaryInfo(@RequestBody PlaceReqDto req) throws Exception {
-        List<PlaceResDto> placeSummaryInfo = placeService.getPlaceSummaryInfo(req);
+    public ResponseEntity<?> searchSummaryInfo(@RequestBody PlaceReqDto req) throws Exception {
+        List<PlaceResDto> placeSummaryInfo = placeService.getPlacesSummaryInfo(req);
 
         return MessageUtil.buildResponseEntity(placeSummaryInfo, HttpStatus.OK, "success");
     }
 
-    @GetMapping("/detail")
-    public ResponseEntity<?> getPlaceDetails(@RequestBody PlaceReqDto req) throws Exception {
-        List<PlaceResDto> placeSummaryInfo = placeService.getPlaceSummaryInfo(req);
-
-        return MessageUtil.buildResponseEntity(placeSummaryInfo, HttpStatus.OK, "success");
-    }
+//    @GetMapping("/details")
+//    public ResponseEntity<?> searchPlaceDetails(@RequestParam("kakaoPlaceId") Long kakaoPlaceId,
+//                                             @RequestParam("sortBy") String sort,
+//                                             @RequestParam("page") int page) throws Exception {
+//
+//       placeService.getPlacesDetails(kakaoPlaceId, sort, page);
+//
+//    }
 }

--- a/src/main/java/com/plac/controller/PlaceController.java
+++ b/src/main/java/com/plac/controller/PlaceController.java
@@ -1,17 +1,13 @@
 package com.plac.controller;
 
 import com.plac.dto.request.place.PlaceReqDto;
-import com.plac.dto.request.user.UserReqDto;
 import com.plac.dto.response.place.PlaceResDto;
 import com.plac.service.place.PlaceService;
 import com.plac.util.MessageUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,6 +20,13 @@ public class PlaceController {
 
     @PostMapping("")
     public ResponseEntity<?> searchPlaceSummaryInfo(@RequestBody PlaceReqDto req) throws Exception {
+        List<PlaceResDto> placeSummaryInfo = placeService.getPlaceSummaryInfo(req);
+
+        return MessageUtil.buildResponseEntity(placeSummaryInfo, HttpStatus.OK, "success");
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<?> getPlaceDetails(@RequestBody PlaceReqDto req) throws Exception {
         List<PlaceResDto> placeSummaryInfo = placeService.getPlaceSummaryInfo(req);
 
         return MessageUtil.buildResponseEntity(placeSummaryInfo, HttpStatus.OK, "success");

--- a/src/main/java/com/plac/controller/PlaceReviewController.java
+++ b/src/main/java/com/plac/controller/PlaceReviewController.java
@@ -1,16 +1,16 @@
 package com.plac.controller;
 
-import com.plac.dto.request.place_review.AddLikeToPlaceReviewReqDto;
+import com.plac.dto.request.place_review.PlaceReviewRateReqDto;
 import com.plac.dto.request.place_review.PlaceReviewReqDto;
+import com.plac.dto.response.place_review.PlaceReviewResDto;
 import com.plac.service.place_review.PlaceReviewService;
 import com.plac.util.MessageUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,10 +26,28 @@ public class PlaceReviewController {
         return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
     }
 
-    @PostMapping("/rate")
-    public ResponseEntity<?> addLikeToPlaceReview(@RequestBody AddLikeToPlaceReviewReqDto req){
-        placeReviewService.ratePlaceReview(req);
+    @PostMapping("/like")
+    public ResponseEntity<?> addLikeToPlaceReview(@RequestBody PlaceReviewRateReqDto req){
+        placeReviewService.addLikeToPlaceReview(req);
 
         return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
     }
+
+    @PostMapping("/disLike")
+    public ResponseEntity<?> addiDisLikeToPlaceReview(@RequestBody PlaceReviewRateReqDto req){
+        placeReviewService.addDisLikeToPlaceReview(req);
+
+        return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
+    }
+
+    @GetMapping("/paging")
+    public ResponseEntity<?> searchPlaceReviews(@RequestParam("placeId") Long placeId,
+                                             @RequestParam("sortBy") String sortBy,
+                                             @RequestParam("page") int page) {
+
+        List<PlaceReviewResDto> placeReviews = placeReviewService.getPlaceReviews(placeId, sortBy, page);
+
+        return MessageUtil.buildResponseEntity(placeReviews, HttpStatus.OK, "success");
+    }
+
 }

--- a/src/main/java/com/plac/controller/PlaceReviewController.java
+++ b/src/main/java/com/plac/controller/PlaceReviewController.java
@@ -1,5 +1,6 @@
 package com.plac.controller;
 
+import com.plac.dto.request.place_review.AddLikeToPlaceReviewReqDto;
 import com.plac.dto.request.place_review.PlaceReviewReqDto;
 import com.plac.service.place_review.PlaceReviewService;
 import com.plac.util.MessageUtil;
@@ -21,6 +22,13 @@ public class PlaceReviewController {
     @PostMapping("")
     public ResponseEntity<?> writePlaceReview(@RequestBody PlaceReviewReqDto req){
         placeReviewService.writeReview(req);
+
+        return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
+    }
+
+    @PostMapping("/rate")
+    public ResponseEntity<?> addLikeToPlaceReview(@RequestBody AddLikeToPlaceReviewReqDto req){
+        placeReviewService.ratePlaceReview(req);
 
         return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
     }

--- a/src/main/java/com/plac/controller/PlaceReviewController.java
+++ b/src/main/java/com/plac/controller/PlaceReviewController.java
@@ -1,0 +1,27 @@
+package com.plac.controller;
+
+import com.plac.dto.request.place_review.PlaceReviewReqDto;
+import com.plac.service.place_review.PlaceReviewService;
+import com.plac.util.MessageUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/place-review")
+public class PlaceReviewController {
+
+    private final PlaceReviewService placeReviewService;
+
+    @PostMapping("")
+    public ResponseEntity<?> writePlaceReview(@RequestBody PlaceReviewReqDto req){
+        placeReviewService.writeReview(req);
+
+        return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
+    }
+}

--- a/src/main/java/com/plac/domain/Place.java
+++ b/src/main/java/com/plac/domain/Place.java
@@ -1,15 +1,13 @@
 package com.plac.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -24,7 +22,7 @@ public class Place extends AbstractTimeEntity {
 
     private Long kakaoPlaceId;
 
-    private String name;
+    private String placeName;
 
     private String thumbnailImageUrl;
 

--- a/src/main/java/com/plac/domain/Place.java
+++ b/src/main/java/com/plac/domain/Place.java
@@ -1,0 +1,39 @@
+package com.plac.domain;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place")
+public class Place extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    private Long kakaoPlaceId;
+
+    private String name;
+
+    private String thumbnailImageUrl;
+
+    private String streetNameAddress;
+
+    @Column(precision=11, scale=8)
+    private BigDecimal latitude;
+
+    @Column(precision=11, scale=8)
+    private BigDecimal longitude;
+
+}

--- a/src/main/java/com/plac/domain/Place.java
+++ b/src/main/java/com/plac/domain/Place.java
@@ -1,10 +1,10 @@
 package com.plac.domain;
 
-import com.plac.domain.AbstractTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
@@ -31,9 +31,11 @@ public class Place extends AbstractTimeEntity {
     private String streetNameAddress;
 
     @Column(precision=11, scale=8)
-    private BigDecimal latitude;
+    @Comment("장소의 경도 : longitude")
+    private BigDecimal x;
 
     @Column(precision=11, scale=8)
-    private BigDecimal longitude;
+    @Comment("장소의 위도 : latitude")
+    private BigDecimal y;
 
 }

--- a/src/main/java/com/plac/domain/place_review/PlaceReview.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReview.java
@@ -1,0 +1,65 @@
+package com.plac.domain.place_review;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_review")
+public class PlaceReview extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "place_id", nullable = false)
+    private Long placeId;
+
+    @Column(name = "total_rating")
+    private Integer totalRating;
+
+    @Column(name = "flavor_rating")
+    private Integer flavorRating;
+
+    @Column(name = "price_rating")
+    private Integer priceRating;
+
+    @Column(name = "kindness_rating")
+    private Integer kindnessRating;
+
+    @Column(name = "cleanness_rating")
+    private Integer cleannessRating;
+
+    @Column(name = "mood_rating")
+    private Integer moodRating;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @OneToMany(mappedBy = "placeReview")
+    private Set<PlaceReviewTagMapping> placeReviewTagMappings = new HashSet<>();
+
+    @OneToMany(mappedBy = "placeReview")
+    private Set<PlaceReviewImage> placeReviewImages = new HashSet<>();
+
+    @OneToMany(mappedBy = "placeReview")
+    private Set<PlaceReviewLike> placeReviewLikes = new HashSet<>();
+
+    @OneToMany(mappedBy = "placeReview")
+    private Set<PlaceReviewDislike> placeReviewDislikes = new HashSet<>();
+
+}

--- a/src/main/java/com/plac/domain/place_review/PlaceReview.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReview.java
@@ -27,23 +27,8 @@ public class PlaceReview extends AbstractTimeEntity {
     @Column(name = "place_id", nullable = false)
     private Long placeId;
 
-    @Column(name = "total_rating")
-    private Integer totalRating;
-
-    @Column(name = "flavor_rating")
-    private Integer flavorRating;
-
-    @Column(name = "price_rating")
-    private Integer priceRating;
-
-    @Column(name = "kindness_rating")
-    private Integer kindnessRating;
-
-    @Column(name = "cleanness_rating")
-    private Integer cleannessRating;
-
-    @Column(name = "mood_rating")
-    private Integer moodRating;
+    @Embedded
+    private Ratings ratings;
 
     @Lob
     @Column(nullable = false)

--- a/src/main/java/com/plac/domain/place_review/PlaceReview.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReview.java
@@ -15,7 +15,9 @@ import java.util.Set;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "place_review")
+@Table(name = "place_review", indexes = {
+        @Index(name = "idx_place_id", columnList = "place_id")
+})
 public class PlaceReview extends AbstractTimeEntity {
 
     @Id

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewDislike.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewDislike.java
@@ -13,7 +13,9 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "place_review_dislike")
+@Table(name = "place_review_dislike", indexes = {
+        @Index(name = "idx_place_review_user", columnList = "place_review_id, user_id")
+})
 public class PlaceReviewDislike extends AbstractTimeEntity {
 
     @Id

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewDislike.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewDislike.java
@@ -1,0 +1,30 @@
+package com.plac.domain.place_review;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_review_dislike")
+public class PlaceReviewDislike extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "place_review_id", nullable = false)
+    private PlaceReview placeReview;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+}

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewImage.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewImage.java
@@ -1,0 +1,32 @@
+package com.plac.domain.place_review;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_review_image")
+public class PlaceReviewImage extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int turn;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "place_review_id", nullable = false)
+    private PlaceReview placeReview;
+
+}

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewImage.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewImage.java
@@ -13,7 +13,9 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "place_review_image")
+@Table(name = "place_review_image", indexes = {
+        @Index(name = "idx_place_review_turn", columnList = "place_review_id, turn")
+})
 public class PlaceReviewImage extends AbstractTimeEntity {
 
     @Id

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewLike.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewLike.java
@@ -1,0 +1,39 @@
+package com.plac.domain.place_review;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_review_like")
+public class PlaceReviewLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "place_review_id", nullable = false)
+    private PlaceReview placeReview;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "created_at", updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    @Column(name = "updated_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date updatedAt;
+
+}
+

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewLike.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewLike.java
@@ -13,7 +13,9 @@ import java.util.Date;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "place_review_like")
+@Table(name = "place_review_like", indexes = {
+        @Index(name = "idx_place_review_user", columnList = "place_review_id, user_id")
+})
 public class PlaceReviewLike {
 
     @Id

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewLike.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewLike.java
@@ -1,5 +1,6 @@
 package com.plac.domain.place_review;
 
+import com.plac.domain.AbstractTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import java.util.Date;
 @Table(name = "place_review_like", indexes = {
         @Index(name = "idx_place_review_user", columnList = "place_review_id, user_id")
 })
-public class PlaceReviewLike {
+public class PlaceReviewLike extends AbstractTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,14 +29,6 @@ public class PlaceReviewLike {
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
-
-    @Column(name = "created_at", updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date createdAt;
-
-    @Column(name = "updated_at")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date updatedAt;
 
 }
 

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewTag.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewTag.java
@@ -23,7 +23,7 @@ public class PlaceReviewTag extends AbstractTimeEntity {
     private Long id;
 
     @Column(unique = true, nullable = false)
-    private String name;
+    private String tagName;
 
     @OneToMany(mappedBy = "placeReviewTag")
     private Set<PlaceReviewTagMapping> placeReviewTagMappings = new HashSet<>();

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewTag.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewTag.java
@@ -1,0 +1,32 @@
+package com.plac.domain.place_review;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_review_tag")
+public class PlaceReviewTag extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "placeReviewTag")
+    private Set<PlaceReviewTagMapping> placeReviewTagMappings = new HashSet<>();
+
+}
+

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewTagMapping.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewTagMapping.java
@@ -13,7 +13,9 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "place_review_tag_mapping")
+@Table(name = "place_review_tag_mapping", indexes = {
+        @Index(name = "idx_place_review_id", columnList = "place_review_id")
+})
 public class PlaceReviewTagMapping extends AbstractTimeEntity {
 
     @Id

--- a/src/main/java/com/plac/domain/place_review/PlaceReviewTagMapping.java
+++ b/src/main/java/com/plac/domain/place_review/PlaceReviewTagMapping.java
@@ -1,0 +1,31 @@
+package com.plac.domain.place_review;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_review_tag_mapping")
+public class PlaceReviewTagMapping extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "place_review_id", nullable = false)
+    private PlaceReview placeReview;
+
+    @ManyToOne
+    @JoinColumn(name = "place_review_tag_id", nullable = false)
+    private PlaceReviewTag placeReviewTag;
+
+}

--- a/src/main/java/com/plac/domain/place_review/Ratings.java
+++ b/src/main/java/com/plac/domain/place_review/Ratings.java
@@ -1,0 +1,13 @@
+package com.plac.domain.place_review;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Ratings {
+    private Integer totalRating;
+    private Integer flavorRating;
+    private Integer priceRating;
+    private Integer kindnessRating;
+    private Integer cleannessRating;
+    private Integer moodRating;
+}

--- a/src/main/java/com/plac/domain/place_review/Ratings.java
+++ b/src/main/java/com/plac/domain/place_review/Ratings.java
@@ -1,13 +1,20 @@
 package com.plac.domain.place_review;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Embeddable;
 
 @Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public class Ratings {
-    private Integer totalRating;
-    private Integer flavorRating;
-    private Integer priceRating;
-    private Integer kindnessRating;
-    private Integer cleannessRating;
-    private Integer moodRating;
+    private double totalRating;
+    private int flavorRating;
+    private int priceRating;
+    private int kindnessRating;
+    private int cleannessRating;
+    private int moodRating;
 }

--- a/src/main/java/com/plac/domain/place_tag/PlaceTag.java
+++ b/src/main/java/com/plac/domain/place_tag/PlaceTag.java
@@ -1,0 +1,32 @@
+package com.plac.domain.place_tag;
+
+import com.plac.domain.AbstractTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_tag")
+public class PlaceTag extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "placeTag")
+    private Set<PlaceTagMapping> placeTagMappings = new HashSet<>();
+
+}
+

--- a/src/main/java/com/plac/domain/place_tag/PlaceTagMapping.java
+++ b/src/main/java/com/plac/domain/place_tag/PlaceTagMapping.java
@@ -1,0 +1,34 @@
+package com.plac.domain.place_tag;
+
+import com.plac.domain.Place;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "place_tag_mapping", indexes = {
+        @Index(name = "idx_place_id", columnList = "place_id"),
+        @Index(name = "idx_place_tag_id", columnList = "place_tag_id")
+})
+public class PlaceTagMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @ManyToOne
+    @JoinColumn(name = "place_tag_id", nullable = false)
+    private PlaceTag placeTag;
+
+}

--- a/src/main/java/com/plac/domain/place_tag/PlaceTagMapping.java
+++ b/src/main/java/com/plac/domain/place_tag/PlaceTagMapping.java
@@ -1,5 +1,6 @@
 package com.plac.domain.place_tag;
 
+import com.plac.domain.AbstractTimeEntity;
 import com.plac.domain.Place;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +18,7 @@ import javax.persistence.*;
         @Index(name = "idx_place_id", columnList = "place_id"),
         @Index(name = "idx_place_tag_id", columnList = "place_tag_id")
 })
-public class PlaceTagMapping {
+public class PlaceTagMapping extends AbstractTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/plac/dto/request/place/KakaoPlaceInfo.java
+++ b/src/main/java/com/plac/dto/request/place/KakaoPlaceInfo.java
@@ -10,6 +10,9 @@ import java.math.BigDecimal;
 @Builder
 public class KakaoPlaceInfo {
     private Long kakaoPlaceId;
+    private String placeName;
+    private String thumbnailImageUrl;
+    private String streetNameAddress;
     private BigDecimal x;
     private BigDecimal y;
 }

--- a/src/main/java/com/plac/dto/request/place/KakaoPlaceInfo.java
+++ b/src/main/java/com/plac/dto/request/place/KakaoPlaceInfo.java
@@ -1,0 +1,15 @@
+package com.plac.dto.request.place;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoPlaceInfo {
+    private Long kakaoPlaceId;
+    private BigDecimal x;
+    private BigDecimal y;
+}

--- a/src/main/java/com/plac/dto/request/place/PlaceDetailsReqDto.java
+++ b/src/main/java/com/plac/dto/request/place/PlaceDetailsReqDto.java
@@ -1,0 +1,14 @@
+package com.plac.dto.request.place;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlaceDetailsReqDto {
+    private Long placeId;
+}

--- a/src/main/java/com/plac/dto/request/place/PlaceReqDto.java
+++ b/src/main/java/com/plac/dto/request/place/PlaceReqDto.java
@@ -1,0 +1,16 @@
+package com.plac.dto.request.place;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlaceReqDto {
+    private List<KakaoPlaceInfo> positionList;
+}

--- a/src/main/java/com/plac/dto/request/place_review/AddLikeToPlaceReviewReqDto.java
+++ b/src/main/java/com/plac/dto/request/place_review/AddLikeToPlaceReviewReqDto.java
@@ -1,0 +1,17 @@
+package com.plac.dto.request.place_review;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddLikeToPlaceReviewReqDto {
+
+    private Long placeReviewId;
+    private boolean like;
+    private boolean dislike;
+}

--- a/src/main/java/com/plac/dto/request/place_review/PlaceReviewRateReqDto.java
+++ b/src/main/java/com/plac/dto/request/place_review/PlaceReviewRateReqDto.java
@@ -2,16 +2,13 @@ package com.plac.dto.request.place_review;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AddLikeToPlaceReviewReqDto {
-
+public class PlaceReviewRateReqDto {
     private Long placeReviewId;
-    private boolean like;
-    private boolean dislike;
 }

--- a/src/main/java/com/plac/dto/request/place_review/PlaceReviewReqDto.java
+++ b/src/main/java/com/plac/dto/request/place_review/PlaceReviewReqDto.java
@@ -1,0 +1,26 @@
+package com.plac.dto.request.place_review;
+
+import com.plac.domain.place_review.Ratings;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embedded;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceReviewReqDto {
+
+    @Embedded
+    private Ratings ratings;
+
+    private Long kakaoPlaceId;
+    private Long placeId;
+    private String content;
+    private List<String> pictureUrl;
+    private List<String> tags;
+}

--- a/src/main/java/com/plac/dto/response/place/PlaceDetailsResDto.java
+++ b/src/main/java/com/plac/dto/response/place/PlaceDetailsResDto.java
@@ -13,12 +13,9 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlaceDetailsResDto {
-    private Long kakaoPlaceId;
-    private Long placPlaceId;
-    private BigDecimal x;
-    private BigDecimal y;
+    private Long placeId;
+    private String placeName;
+    private String streetNameAddress;
     private int reviewCount;
-    private Ratings averageRatings;
-    private String sortBy;
-    private String page;
+    private float totalRatings;
 }

--- a/src/main/java/com/plac/dto/response/place/PlaceDetailsResDto.java
+++ b/src/main/java/com/plac/dto/response/place/PlaceDetailsResDto.java
@@ -1,0 +1,24 @@
+package com.plac.dto.response.place;
+
+import com.plac.domain.place_review.Ratings;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceDetailsResDto {
+    private Long kakaoPlaceId;
+    private Long placPlaceId;
+    private BigDecimal x;
+    private BigDecimal y;
+    private int reviewCount;
+    private Ratings averageRatings;
+    private String sortBy;
+    private String page;
+}

--- a/src/main/java/com/plac/dto/response/place/PlaceResDto.java
+++ b/src/main/java/com/plac/dto/response/place/PlaceResDto.java
@@ -1,0 +1,21 @@
+package com.plac.dto.response.place;
+
+import com.plac.domain.Place;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlaceResDto {
+    private Long kakaoPlaceId;
+    private Long placPlaceId;
+    private float totalRating;
+    private int reviewCount;
+    private BigDecimal x;
+    private BigDecimal y;
+
+}

--- a/src/main/java/com/plac/dto/response/place/PlaceResDto.java
+++ b/src/main/java/com/plac/dto/response/place/PlaceResDto.java
@@ -6,13 +6,15 @@ import lombok.*;
 import java.math.BigDecimal;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class PlaceResDto {
     private Long kakaoPlaceId;
     private Long placPlaceId;
+    private String placeName;
+    private String thumbnailImageUrl;
+    private String streetNameAddress;
     private float totalRating;
     private int reviewCount;
     private BigDecimal x;

--- a/src/main/java/com/plac/dto/response/place_review/PlaceReviewResDto.java
+++ b/src/main/java/com/plac/dto/response/place_review/PlaceReviewResDto.java
@@ -1,0 +1,11 @@
+package com.plac.dto.response.place_review;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PlaceReviewResDto {
+}

--- a/src/main/java/com/plac/dto/response/place_review/PlaceReviewResDto.java
+++ b/src/main/java/com/plac/dto/response/place_review/PlaceReviewResDto.java
@@ -1,11 +1,28 @@
 package com.plac.dto.response.place_review;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.plac.domain.User;
+import com.plac.domain.place_review.PlaceReview;
+import com.plac.domain.place_review.Ratings;
+import com.plac.dto.response.user.UserResDto;
+import com.plac.service.user.UserService;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class PlaceReviewResDto {
+    private Long id;
+    private Long userId;
+    private String userProfileName;
+    private LocalDateTime createdAt;
+    private Ratings ratings;
+    private String content;
+    private int like;
+    private int dislike;
+    private boolean myReview;
+    private boolean pickLike;
+    private boolean pickDisLike;
 }

--- a/src/main/java/com/plac/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/plac/exception/CustomExceptionHandler.java
@@ -3,6 +3,8 @@ package com.plac.exception;
 import com.plac.domain.Message;
 import com.plac.exception.place.WrongKakaoPlaceIdException;
 import com.plac.exception.place.WrongPlaceIdException;
+import com.plac.exception.place_review.CannotRateReviewException;
+import com.plac.exception.place_review.PlaceReviewNotFoundException;
 import com.plac.exception.social_login.ProviderNotSupportedException;
 import com.plac.exception.user.DuplUsernameException;
 import com.plac.exception.user.UserPrincipalNotFoundException;
@@ -62,6 +64,18 @@ public class CustomExceptionHandler {
     @ExceptionHandler(WrongPlaceIdException.class)
     public ResponseEntity<?> handleException(WrongPlaceIdException e){
         Message message = new Message(e.getMessage(), -301, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @ExceptionHandler(PlaceReviewNotFoundException.class)
+    public ResponseEntity<?> handleException(PlaceReviewNotFoundException e){
+        Message message = new Message(e.getMessage(), -302, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @ExceptionHandler(CannotRateReviewException.class)
+    public ResponseEntity<?> handleException(CannotRateReviewException e){
+        Message message = new Message(e.getMessage(), -303, HttpStatus.BAD_REQUEST);
         return new ResponseEntity<>(message, message.getStatus());
     }
 

--- a/src/main/java/com/plac/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/plac/exception/CustomExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.plac.exception;
 
 import com.plac.domain.Message;
+import com.plac.exception.place.WrongKakaoPlaceIdException;
+import com.plac.exception.place.WrongPlaceIdException;
 import com.plac.exception.social_login.ProviderNotSupportedException;
 import com.plac.exception.user.DuplUsernameException;
 import com.plac.exception.user.UserPrincipalNotFoundException;
@@ -48,6 +50,18 @@ public class CustomExceptionHandler {
     @ExceptionHandler(ProviderNotSupportedException.class)
     public ResponseEntity<?> handleException(ProviderNotSupportedException e){
         Message message = new Message(e.getMessage(), -201, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @ExceptionHandler(WrongKakaoPlaceIdException.class)
+    public ResponseEntity<?> handleException(WrongKakaoPlaceIdException e){
+        Message message = new Message(e.getMessage(), -300, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @ExceptionHandler(WrongPlaceIdException.class)
+    public ResponseEntity<?> handleException(WrongPlaceIdException e){
+        Message message = new Message(e.getMessage(), -301, HttpStatus.BAD_REQUEST);
         return new ResponseEntity<>(message, message.getStatus());
     }
 

--- a/src/main/java/com/plac/exception/place/WrongKakaoPlaceIdException.java
+++ b/src/main/java/com/plac/exception/place/WrongKakaoPlaceIdException.java
@@ -1,0 +1,16 @@
+package com.plac.exception.place;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class WrongKakaoPlaceIdException extends RuntimeException {
+
+    private String message;
+    public WrongKakaoPlaceIdException(String message) {
+        super(message);
+        this.message = message;
+    }
+}

--- a/src/main/java/com/plac/exception/place/WrongPlaceIdException.java
+++ b/src/main/java/com/plac/exception/place/WrongPlaceIdException.java
@@ -1,0 +1,16 @@
+package com.plac.exception.place;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class WrongPlaceIdException extends RuntimeException {
+
+    private String message;
+    public WrongPlaceIdException(String message) {
+        super(message);
+        this.message = message;
+    }
+}

--- a/src/main/java/com/plac/exception/place_review/CannotRateReviewException.java
+++ b/src/main/java/com/plac/exception/place_review/CannotRateReviewException.java
@@ -1,0 +1,16 @@
+package com.plac.exception.place_review;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class CannotRateReviewException extends RuntimeException {
+    private String message;
+
+    public CannotRateReviewException(String message) {
+        super(message);
+        this.message = message;
+    }
+}

--- a/src/main/java/com/plac/exception/place_review/PlaceReviewNotFoundException.java
+++ b/src/main/java/com/plac/exception/place_review/PlaceReviewNotFoundException.java
@@ -1,0 +1,16 @@
+package com.plac.exception.place_review;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class PlaceReviewNotFoundException extends RuntimeException {
+    private String message;
+
+    public PlaceReviewNotFoundException(String message) {
+        super(message);
+        this.message = message;
+    }
+}

--- a/src/main/java/com/plac/repository/PlaceRepository.java
+++ b/src/main/java/com/plac/repository/PlaceRepository.java
@@ -1,0 +1,10 @@
+package com.plac.repository;
+
+import com.plac.domain.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Optional<Place> findByKakaoPlaceId(Long kakaoPlaceId);
+}

--- a/src/main/java/com/plac/repository/PlaceReviewDislikeRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewDislikeRepository.java
@@ -1,0 +1,7 @@
+package com.plac.repository;
+
+import com.plac.domain.place_review.PlaceReviewDislike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewDislikeRepository extends JpaRepository<PlaceReviewDislike, Long> {
+}

--- a/src/main/java/com/plac/repository/PlaceReviewDislikeRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewDislikeRepository.java
@@ -1,7 +1,17 @@
 package com.plac.repository;
 
 import com.plac.domain.place_review.PlaceReviewDislike;
+import com.plac.domain.place_review.PlaceReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PlaceReviewDislikeRepository extends JpaRepository<PlaceReviewDislike, Long> {
+    @Query("SELECT COUNT(prdl) FROM PlaceReviewDislike prdl WHERE prdl.placeReview.id = :placeReviewId")
+    int countByPlaceReviewId(@Param("placeReviewId") Long placeReviewId);
+
+    @Query("SELECT prl FROM PlaceReviewDislike prl WHERE prl.placeReview.id = :placeReviewId AND prl.userId = :userId")
+    Optional<PlaceReviewLike> findByPlaceReviewIdAndUserId(@Param("placeReviewId") Long placeReviewId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/plac/repository/PlaceReviewImageRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewImageRepository.java
@@ -1,0 +1,7 @@
+package com.plac.repository;
+
+import com.plac.domain.place_review.PlaceReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewImageRepository extends JpaRepository<PlaceReviewImage, Long> {
+}

--- a/src/main/java/com/plac/repository/PlaceReviewLikeRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewLikeRepository.java
@@ -2,6 +2,15 @@ package com.plac.repository;
 
 import com.plac.domain.place_review.PlaceReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PlaceReviewLikeRepository extends JpaRepository <PlaceReviewLike, Long> {
+    @Query("SELECT COUNT(prl) FROM PlaceReviewLike prl WHERE prl.placeReview.id = :placeReviewId")
+    int countByPlaceReviewId(@Param("placeReviewId") Long placeReviewId);
+
+    @Query("SELECT prl FROM PlaceReviewLike prl WHERE prl.placeReview.id = :placeReviewId AND prl.userId = :userId")
+    Optional<PlaceReviewLike> findByPlaceReviewIdAndUserId(@Param("placeReviewId") Long placeReviewId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/plac/repository/PlaceReviewLikeRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewLikeRepository.java
@@ -1,0 +1,7 @@
+package com.plac.repository;
+
+import com.plac.domain.place_review.PlaceReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewLikeRepository extends JpaRepository <PlaceReviewLike, Long> {
+}

--- a/src/main/java/com/plac/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewRepository.java
@@ -1,0 +1,14 @@
+package com.plac.repository;
+
+import com.plac.domain.place_review.PlaceReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
+    @Query("SELECT ROUND(AVG(pr.totalRating), 0) FROM PlaceReview pr WHERE pr.placeId = :placeId")
+    Float findAverageTotalRatingByPlaceId(@Param("placeId") Long placeId);
+
+    @Query("SELECT COALESCE(ROUND(AVG(pr.totalRating), 0), 0) FROM PlaceReview pr WHERE pr.placeId = :placeId")
+    int countByPlaceId(@Param("placeId") Long placeId);
+}

--- a/src/main/java/com/plac/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewRepository.java
@@ -1,6 +1,8 @@
 package com.plac.repository;
 
 import com.plac.domain.place_review.PlaceReview;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +13,18 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
 
     @Query("SELECT ROUND(COUNT(pr), 0) FROM PlaceReview pr WHERE pr.placeId = :placeId")
     int countByPlaceId(@Param("placeId") Long placeId);
+
+    @Query("SELECT pr FROM PlaceReview pr LEFT JOIN pr.placeReviewLikes prl " +
+            "GROUP BY pr.id " +
+            "ORDER BY COUNT(prl.id) DESC, pr.createdAt DESC")
+    Page<PlaceReview> findAllOrderByLikesDesc(Pageable pageable);
+
+    @Query("SELECT pr FROM PlaceReview pr WHERE pr.placeId = :placeId ORDER BY pr.createdAt DESC")
+    Page<PlaceReview> findAllOrderByCreatedAtDesc(@Param("placeId") Long placeId, Pageable pageable);
+
+    @Query("SELECT pr FROM PlaceReview pr ORDER BY pr.ratings.totalRating DESC")
+    Page<PlaceReview> findAllOrderByTotalRatingDesc(Pageable pageable);
+
+    @Query("SELECT pr FROM PlaceReview pr ORDER BY pr.ratings.totalRating ASC")
+    Page<PlaceReview> findAllOrderByTotalRatingAsc(Pageable pageable);
 }

--- a/src/main/java/com/plac/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
-    @Query("SELECT ROUND(AVG(pr.totalRating), 0) FROM PlaceReview pr WHERE pr.placeId = :placeId")
+    @Query("SELECT AVG(pr.ratings.totalRating) FROM PlaceReview pr WHERE pr.placeId = :placeId")
     Float findAverageTotalRatingByPlaceId(@Param("placeId") Long placeId);
 
-    @Query("SELECT COALESCE(ROUND(AVG(pr.totalRating), 0), 0) FROM PlaceReview pr WHERE pr.placeId = :placeId")
+    @Query("SELECT ROUND(COUNT(pr), 0) FROM PlaceReview pr WHERE pr.placeId = :placeId")
     int countByPlaceId(@Param("placeId") Long placeId);
 }

--- a/src/main/java/com/plac/repository/PlaceReviewTagMappingRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewTagMappingRepository.java
@@ -1,0 +1,7 @@
+package com.plac.repository;
+
+import com.plac.domain.place_review.PlaceReviewTagMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewTagMappingRepository extends JpaRepository<PlaceReviewTagMapping, Long> {
+}

--- a/src/main/java/com/plac/repository/PlaceReviewTagRepository.java
+++ b/src/main/java/com/plac/repository/PlaceReviewTagRepository.java
@@ -1,0 +1,10 @@
+package com.plac.repository;
+
+import com.plac.domain.place_review.PlaceReviewTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaceReviewTagRepository extends JpaRepository<PlaceReviewTag, Long> {
+    Optional<PlaceReviewTag> findByTagName(String tagName);
+}

--- a/src/main/java/com/plac/service/place/PlaceService.java
+++ b/src/main/java/com/plac/service/place/PlaceService.java
@@ -2,7 +2,9 @@ package com.plac.service.place;
 
 import com.plac.domain.Place;
 import com.plac.dto.request.place.KakaoPlaceInfo;
+import com.plac.dto.request.place.PlaceDetailsReqDto;
 import com.plac.dto.request.place.PlaceReqDto;
+import com.plac.dto.response.place.PlaceDetailsResDto;
 import com.plac.dto.response.place.PlaceResDto;
 
 import java.util.List;
@@ -13,4 +15,5 @@ public interface PlaceService {
     List<PlaceResDto> getPlacesSummaryInfo(PlaceReqDto req);
     Place createNewPlace(KakaoPlaceInfo req);
 
+    PlaceDetailsResDto getPlaceDetails(Long placeId);
 }

--- a/src/main/java/com/plac/service/place/PlaceService.java
+++ b/src/main/java/com/plac/service/place/PlaceService.java
@@ -1,0 +1,16 @@
+package com.plac.service.place;
+
+import com.plac.domain.Place;
+import com.plac.dto.request.place.KakaoPlaceInfo;
+import com.plac.dto.request.place.PlaceReqDto;
+import com.plac.dto.response.place.PlaceResDto;
+
+import java.util.List;
+
+public interface PlaceService {
+
+    float getTotalRatingAverage(Long placeId);
+    List<PlaceResDto> getPlaceSummaryInfo(PlaceReqDto req);
+    Place createNewPlace(KakaoPlaceInfo req);
+
+}

--- a/src/main/java/com/plac/service/place/PlaceService.java
+++ b/src/main/java/com/plac/service/place/PlaceService.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface PlaceService {
 
     float getTotalRatingAverage(Long placeId);
-    List<PlaceResDto> getPlaceSummaryInfo(PlaceReqDto req);
+    List<PlaceResDto> getPlacesSummaryInfo(PlaceReqDto req);
     Place createNewPlace(KakaoPlaceInfo req);
 
 }

--- a/src/main/java/com/plac/service/place/PlaceServiceImpl.java
+++ b/src/main/java/com/plac/service/place/PlaceServiceImpl.java
@@ -1,0 +1,70 @@
+package com.plac.service.place;
+
+import com.plac.domain.Place;
+import com.plac.dto.request.place.KakaoPlaceInfo;
+import com.plac.dto.request.place.PlaceReqDto;
+import com.plac.dto.response.place.PlaceResDto;
+import com.plac.repository.PlaceRepository;
+import com.plac.repository.PlaceReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceServiceImpl implements PlaceService{
+
+    private final PlaceReviewRepository placeReviewRepository;
+    private final PlaceRepository placeRepository;
+
+    @Override
+    public float getTotalRatingAverage(Long placeId) {
+        float totalRatingAverage = placeReviewRepository.findAverageTotalRatingByPlaceId(placeId);
+        return totalRatingAverage;
+    }
+
+    @Override
+    public List<PlaceResDto> getPlaceSummaryInfo(PlaceReqDto req) {
+        List<KakaoPlaceInfo> placeInfoList = req.getPositionList();
+        List<PlaceResDto> result = new ArrayList<>();
+
+        for (KakaoPlaceInfo placeInfo : placeInfoList) {
+            Place place = placeRepository.findByKakaoPlaceId(placeInfo.getKakaoPlaceId())
+                    .orElseGet(() -> createNewPlace(placeInfo));
+
+            PlaceResDto placeResDto = buildPlaceResDto(place, placeInfo);
+            result.add(placeResDto);
+        }
+
+        return result;
+    }
+
+    @Override
+    public Place createNewPlace(KakaoPlaceInfo req) {
+        Place newPlace = Place.builder()
+                .kakaoPlaceId(req.getKakaoPlaceId())
+                .x(req.getX())
+                .y(req.getY())
+                .build();
+        return placeRepository.save(newPlace);
+    }
+
+    private PlaceResDto buildPlaceResDto(Place place, KakaoPlaceInfo placeInfo) {
+        int reviewCount = placeReviewRepository.countByPlaceId(place.getId());
+
+        Float averageTotalRating = placeReviewRepository.findAverageTotalRatingByPlaceId(place.getId());
+        if (averageTotalRating == null) averageTotalRating = 0.0f;
+
+        return PlaceResDto.builder()
+                .kakaoPlaceId(placeInfo.getKakaoPlaceId())
+                .placPlaceId(place.getId())
+                .totalRating(averageTotalRating)
+                .reviewCount(reviewCount)
+                .x(place.getX())
+                .y(place.getY())
+                .build();
+    }
+
+}

--- a/src/main/java/com/plac/service/place/PlaceServiceImpl.java
+++ b/src/main/java/com/plac/service/place/PlaceServiceImpl.java
@@ -2,8 +2,11 @@ package com.plac.service.place;
 
 import com.plac.domain.Place;
 import com.plac.dto.request.place.KakaoPlaceInfo;
+import com.plac.dto.request.place.PlaceDetailsReqDto;
 import com.plac.dto.request.place.PlaceReqDto;
+import com.plac.dto.response.place.PlaceDetailsResDto;
 import com.plac.dto.response.place.PlaceResDto;
+import com.plac.exception.place.WrongPlaceIdException;
 import com.plac.repository.PlaceRepository;
 import com.plac.repository.PlaceReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ public class PlaceServiceImpl implements PlaceService{
         float totalRatingAverage = placeReviewRepository.findAverageTotalRatingByPlaceId(placeId);
         return totalRatingAverage;
     }
+
 
     @Override
     public List<PlaceResDto> getPlacesSummaryInfo(PlaceReqDto req) {
@@ -52,6 +57,26 @@ public class PlaceServiceImpl implements PlaceService{
                 .build();
         return placeRepository.save(newPlace);
     }
+
+    @Override
+    public PlaceDetailsResDto getPlaceDetails(Long placeId) {
+        Optional<Place> placeOpt = placeRepository.findById(placeId);
+        if(!placeOpt.isPresent())
+            throw new WrongPlaceIdException("Wrong placeId");
+
+        Place place = placeOpt.get();
+        Float averageRating = placeReviewRepository.findAverageTotalRatingByPlaceId(place.getId());
+        int reviewCount = placeReviewRepository.countByPlaceId(place.getId());
+
+        return PlaceDetailsResDto.builder()
+                .placeId(place.getId())
+                .placeName(place.getPlaceName())
+                .streetNameAddress(place.getStreetNameAddress())
+                .reviewCount(reviewCount)
+                .totalRatings(averageRating)
+                .build();
+    }
+
 
     private PlaceResDto buildPlaceResDto(Place place, KakaoPlaceInfo placeInfo) {
         int reviewCount = placeReviewRepository.countByPlaceId(place.getId());

--- a/src/main/java/com/plac/service/place/PlaceServiceImpl.java
+++ b/src/main/java/com/plac/service/place/PlaceServiceImpl.java
@@ -2,7 +2,6 @@ package com.plac.service.place;
 
 import com.plac.domain.Place;
 import com.plac.dto.request.place.KakaoPlaceInfo;
-import com.plac.dto.request.place.PlaceDetailsReqDto;
 import com.plac.dto.request.place.PlaceReqDto;
 import com.plac.dto.response.place.PlaceDetailsResDto;
 import com.plac.dto.response.place.PlaceResDto;

--- a/src/main/java/com/plac/service/place/PlaceServiceImpl.java
+++ b/src/main/java/com/plac/service/place/PlaceServiceImpl.java
@@ -56,6 +56,9 @@ public class PlaceServiceImpl implements PlaceService{
 
         Float averageTotalRating = placeReviewRepository.findAverageTotalRatingByPlaceId(place.getId());
         if (averageTotalRating == null) averageTotalRating = 0.0f;
+        else{
+            averageTotalRating = Math.round(averageTotalRating * 10) / 10.0f;
+        }
 
         return PlaceResDto.builder()
                 .kakaoPlaceId(placeInfo.getKakaoPlaceId())

--- a/src/main/java/com/plac/service/place/PlaceServiceImpl.java
+++ b/src/main/java/com/plac/service/place/PlaceServiceImpl.java
@@ -26,14 +26,13 @@ public class PlaceServiceImpl implements PlaceService{
     }
 
     @Override
-    public List<PlaceResDto> getPlaceSummaryInfo(PlaceReqDto req) {
+    public List<PlaceResDto> getPlacesSummaryInfo(PlaceReqDto req) {
         List<KakaoPlaceInfo> placeInfoList = req.getPositionList();
         List<PlaceResDto> result = new ArrayList<>();
 
         for (KakaoPlaceInfo placeInfo : placeInfoList) {
             Place place = placeRepository.findByKakaoPlaceId(placeInfo.getKakaoPlaceId())
                     .orElseGet(() -> createNewPlace(placeInfo));
-
             PlaceResDto placeResDto = buildPlaceResDto(place, placeInfo);
             result.add(placeResDto);
         }
@@ -45,6 +44,9 @@ public class PlaceServiceImpl implements PlaceService{
     public Place createNewPlace(KakaoPlaceInfo req) {
         Place newPlace = Place.builder()
                 .kakaoPlaceId(req.getKakaoPlaceId())
+                .placeName(req.getPlaceName())
+                .thumbnailImageUrl(req.getThumbnailImageUrl())
+                .streetNameAddress(req.getStreetNameAddress())
                 .x(req.getX())
                 .y(req.getY())
                 .build();
@@ -63,6 +65,9 @@ public class PlaceServiceImpl implements PlaceService{
         return PlaceResDto.builder()
                 .kakaoPlaceId(placeInfo.getKakaoPlaceId())
                 .placPlaceId(place.getId())
+                .placeName(placeInfo.getPlaceName())
+                .thumbnailImageUrl(placeInfo.getThumbnailImageUrl())
+                .streetNameAddress(placeInfo.getStreetNameAddress())
                 .totalRating(averageTotalRating)
                 .reviewCount(reviewCount)
                 .x(place.getX())

--- a/src/main/java/com/plac/service/place_review/PlaceReviewService.java
+++ b/src/main/java/com/plac/service/place_review/PlaceReviewService.java
@@ -1,0 +1,11 @@
+package com.plac.service.place_review;
+
+import com.plac.domain.place_review.PlaceReviewTag;
+import com.plac.dto.request.place_review.PlaceReviewReqDto;
+
+public interface PlaceReviewService {
+
+    void writeReview(PlaceReviewReqDto req);
+
+    PlaceReviewTag createPlaceReviewTag(String tagName);
+}

--- a/src/main/java/com/plac/service/place_review/PlaceReviewService.java
+++ b/src/main/java/com/plac/service/place_review/PlaceReviewService.java
@@ -1,8 +1,11 @@
 package com.plac.service.place_review;
 
 import com.plac.domain.place_review.PlaceReviewTag;
-import com.plac.dto.request.place_review.AddLikeToPlaceReviewReqDto;
+import com.plac.dto.request.place_review.PlaceReviewRateReqDto;
 import com.plac.dto.request.place_review.PlaceReviewReqDto;
+import com.plac.dto.response.place_review.PlaceReviewResDto;
+
+import java.util.List;
 
 public interface PlaceReviewService {
 
@@ -10,5 +13,7 @@ public interface PlaceReviewService {
 
     PlaceReviewTag createPlaceReviewTag(String tagName);
 
-    void ratePlaceReview(AddLikeToPlaceReviewReqDto req);
+    void addLikeToPlaceReview(PlaceReviewRateReqDto req);
+    void addDisLikeToPlaceReview(PlaceReviewRateReqDto req);
+    List<PlaceReviewResDto> getPlaceReviews(Long placeId, String sortBy, int page);
 }

--- a/src/main/java/com/plac/service/place_review/PlaceReviewService.java
+++ b/src/main/java/com/plac/service/place_review/PlaceReviewService.java
@@ -1,6 +1,7 @@
 package com.plac.service.place_review;
 
 import com.plac.domain.place_review.PlaceReviewTag;
+import com.plac.dto.request.place_review.AddLikeToPlaceReviewReqDto;
 import com.plac.dto.request.place_review.PlaceReviewReqDto;
 
 public interface PlaceReviewService {
@@ -8,4 +9,6 @@ public interface PlaceReviewService {
     void writeReview(PlaceReviewReqDto req);
 
     PlaceReviewTag createPlaceReviewTag(String tagName);
+
+    void ratePlaceReview(AddLikeToPlaceReviewReqDto req);
 }

--- a/src/main/java/com/plac/service/place_review/PlaceReviewServiceImpl.java
+++ b/src/main/java/com/plac/service/place_review/PlaceReviewServiceImpl.java
@@ -1,9 +1,11 @@
 package com.plac.service.place_review;
 
 import com.plac.domain.Place;
+import com.plac.domain.User;
 import com.plac.domain.place_review.*;
-import com.plac.dto.request.place_review.AddLikeToPlaceReviewReqDto;
+import com.plac.dto.request.place_review.PlaceReviewRateReqDto;
 import com.plac.dto.request.place_review.PlaceReviewReqDto;
+import com.plac.dto.response.place_review.PlaceReviewResDto;
 import com.plac.exception.place.WrongKakaoPlaceIdException;
 import com.plac.exception.place.WrongPlaceIdException;
 import com.plac.exception.place_review.CannotRateReviewException;
@@ -11,8 +13,13 @@ import com.plac.exception.place_review.PlaceReviewNotFoundException;
 import com.plac.repository.*;
 import com.plac.util.SecurityContextHolderUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -27,6 +34,7 @@ public class PlaceReviewServiceImpl implements PlaceReviewService{
     private final PlaceReviewTagMappingRepository placeReviewTagMappingRepository;
     private final PlaceReviewLikeRepository placeReviewLikeRepository;
     private final PlaceReviewDislikeRepository placeReviewDislikeRepository;
+    private final UserRepository userRepository;
 
     // 리뷰 등록 시, 생성되는 테이블 : PlaceReview, PlaceReviewTag, PlaceReviewTagMapping, PlaceReviewImage
     @Override
@@ -85,29 +93,97 @@ public class PlaceReviewServiceImpl implements PlaceReviewService{
     }
 
     @Override
-    public void ratePlaceReview(AddLikeToPlaceReviewReqDto req) {
-        Optional<PlaceReview> placeReviewOpt = placeReviewRepository.findById(req.getPlaceReviewId());
+    public void addLikeToPlaceReview(PlaceReviewRateReqDto req) {
+        PlaceReview placeReview = verifyPlaceReview(placeReviewRepository.findById(req.getPlaceReviewId()));
+
+        PlaceReviewLike placeReviewLike = PlaceReviewLike.builder()
+                .placeReview(placeReview)
+                .userId(SecurityContextHolderUtil.getUserId()).build();
+        placeReviewLikeRepository.save(placeReviewLike);
+    }
+
+    @Override
+    public void addDisLikeToPlaceReview(PlaceReviewRateReqDto req) {
+        PlaceReview placeReview = verifyPlaceReview(placeReviewRepository.findById(req.getPlaceReviewId()));
+
+        PlaceReviewDislike placeReviewLike = PlaceReviewDislike.builder()
+                .placeReview(placeReview)
+                .userId(SecurityContextHolderUtil.getUserId()).build();
+        placeReviewDislikeRepository.save(placeReviewLike);
+    }
+
+    @Override
+    public List<PlaceReviewResDto> getPlaceReviews(Long placeId, String sortBy, int page) {
+        System.out.println("service - getPlaceReviews()");
+        List<PlaceReviewResDto> results = new ArrayList<>();
+
+        if(sortBy.equals("최신순")){
+            // 페이지 번호는 0부터 시작
+            PageRequest pageRequest = PageRequest.of(page, 3); // 페이지 크기는 3
+            Page<PlaceReview> result = placeReviewRepository.findAllOrderByCreatedAtDesc(placeId, pageRequest);
+            List<PlaceReview> placeReviews = result.getContent();
+            for (PlaceReview placeReview : placeReviews) {
+                Long placeReviewId = placeReview.getId();
+                User user = userRepository.findById(placeReview.getUserId()).get();
+                String profileName = user.getProfileName();
+
+                LocalDateTime createdAt = placeReview.getCreatedAt();
+                Ratings ratings = placeReview.getRatings();
+                String content = placeReview.getContent();
+                int likeCount = placeReviewLikeRepository.countByPlaceReviewId(placeReviewId);
+                int disLikeCount = placeReviewDislikeRepository.countByPlaceReviewId(placeReviewId);
+
+                boolean myReview, pickLike, pickDisLike;
+
+                // 해당 리뷰를 쓴 사람과 현재 로그인된 사람이 같다.
+                if(placeReview.getUserId() == SecurityContextHolderUtil.getUserId()){
+                    myReview = true;
+                }else myReview = false;
+
+                Optional<PlaceReviewLike> placeReviewLikeOpt = placeReviewLikeRepository.findByPlaceReviewIdAndUserId(placeReviewId, SecurityContextHolderUtil.getUserId());
+                Optional<PlaceReviewLike> placeReviewDislikeOpt = placeReviewDislikeRepository.findByPlaceReviewIdAndUserId(placeReviewId, SecurityContextHolderUtil.getUserId());
+
+                if(placeReviewLikeOpt.isPresent()){
+                    pickLike = true;
+                }else pickLike = false;
+
+                if(placeReviewDislikeOpt.isPresent()){
+                    pickDisLike = true;
+                }else pickDisLike = false;
+
+                PlaceReviewResDto placeReviewResDto = PlaceReviewResDto.builder()
+                        .id(placeReviewId)
+                        .userId(placeReview.getUserId())
+                        .userProfileName(user.getProfileName())
+                        .createdAt(createdAt)
+                        .ratings(ratings)
+                        .content(content)
+                        .like(likeCount)
+                        .dislike(disLikeCount)
+                        .myReview(myReview)
+                        .pickLike(pickLike)
+                        .pickDisLike(pickDisLike)
+                        .build();
+
+                results.add(placeReviewResDto);
+            }
+        }
+
+        return results;
+    }
+
+    private PlaceReview verifyPlaceReview(Optional<PlaceReview> placeReviewRepository) {
+        Optional<PlaceReview> placeReviewOpt = placeReviewRepository;
         if(!placeReviewOpt.isPresent()){
             throw new PlaceReviewNotFoundException("Wrong placeReviewId");
         }
-
         PlaceReview placeReview = placeReviewOpt.get();
         if(placeReview.getUserId() == SecurityContextHolderUtil.getUserId()){
             throw new CannotRateReviewException("자신의 리뷰는 평가할 수 없습니다.");
         }
-
-        if(req.isLike()){
-            PlaceReviewLike placeReviewLike = PlaceReviewLike.builder()
-                    .placeReview(placeReview)
-                    .userId(SecurityContextHolderUtil.getUserId()).build();
-            placeReviewLikeRepository.save(placeReviewLike);
-        }else if(req.isDislike()){
-            PlaceReviewDislike placeReviewDislike = PlaceReviewDislike.builder()
-                    .placeReview(placeReview)
-                    .userId(SecurityContextHolderUtil.getUserId()).build();
-            placeReviewDislikeRepository.save(placeReviewDislike);
-        }
+        return placeReview;
     }
+
 
 }
 

--- a/src/main/java/com/plac/service/place_review/PlaceReviewServiceImpl.java
+++ b/src/main/java/com/plac/service/place_review/PlaceReviewServiceImpl.java
@@ -1,0 +1,85 @@
+package com.plac.service.place_review;
+
+import com.plac.domain.Place;
+import com.plac.domain.place_review.PlaceReview;
+import com.plac.domain.place_review.PlaceReviewImage;
+import com.plac.domain.place_review.PlaceReviewTag;
+import com.plac.domain.place_review.PlaceReviewTagMapping;
+import com.plac.dto.request.place_review.PlaceReviewReqDto;
+import com.plac.exception.place.WrongKakaoPlaceIdException;
+import com.plac.exception.place.WrongPlaceIdException;
+import com.plac.repository.*;
+import com.plac.util.SecurityContextHolderUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceReviewServiceImpl implements PlaceReviewService{
+
+    private final PlaceReviewRepository placeReviewRepository;
+    private final PlaceRepository placeRepository;
+    private final PlaceReviewTagRepository placeReviewTagRepository;
+    private final PlaceReviewImageRepository placeReviewImageRepository;
+    private final PlaceReviewTagMappingRepository placeReviewTagMappingRepository;
+
+    // 리뷰 등록 시, 생성되는 테이블 : PlaceReview, PlaceReviewTag, PlaceReviewTagMapping, PlaceReviewImage
+    @Override
+    public void writeReview(PlaceReviewReqDto req) {
+        Optional<Place> placeOpt = placeRepository.findByKakaoPlaceId(req.getKakaoPlaceId());
+        if(!placeOpt.isPresent()){
+            throw new WrongKakaoPlaceIdException("Wrong kakaoPlaceId!");
+        }
+        if(placeOpt.get().getId() != req.getPlaceId()){
+            throw new WrongPlaceIdException("Wrong placeId");
+        }
+
+        PlaceReview placeReview = PlaceReview.builder()
+                .placeId(req.getPlaceId())
+                .ratings(req.getRatings())
+                .content(req.getContent())
+                .userId(SecurityContextHolderUtil.getUserId())
+                .build();
+
+        placeReviewRepository.save(placeReview);
+
+        AtomicInteger turn = new AtomicInteger(0);
+
+        if (req.getPictureUrl() != null){
+            req.getPictureUrl().forEach(pictureUrl -> {
+                    PlaceReviewImage placeReviewImage = PlaceReviewImage.builder()
+                            .imageUrl(pictureUrl)
+                            .placeReview(placeReview)
+                            .turn(turn.getAndIncrement())
+                            .build();
+                    placeReviewImageRepository.save(placeReviewImage);
+            });
+        }
+
+        if(req.getTags() != null) {
+            req.getTags().forEach(tag -> {
+                PlaceReviewTag placeReviewTag = placeReviewTagRepository.findByTagName(tag)
+                        .orElseGet(() -> createPlaceReviewTag(tag));
+
+                PlaceReviewTagMapping placeReviewTagMapping = PlaceReviewTagMapping.builder()
+                        .placeReview(placeReview)
+                        .placeReviewTag(placeReviewTag)
+                        .build();
+                placeReviewTagMappingRepository.save(placeReviewTagMapping);
+            });
+        }
+    }
+
+    @Override
+    public PlaceReviewTag createPlaceReviewTag(String tagName){
+        PlaceReviewTag placeReviewTag = PlaceReviewTag.builder()
+                .tagName(tagName).build();
+        return placeReviewTagRepository.save(placeReviewTag);
+    }
+
+
+}
+

--- a/src/main/java/com/plac/service/user/UserServiceImpl.java
+++ b/src/main/java/com/plac/service/user/UserServiceImpl.java
@@ -103,7 +103,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public void checkEmailAvailability(String email) {
-        Optional<User> optionalUser = userRepository.findByUsername(email);
+        Optional<User> optionalUser = userRepository.findByUsernameAndProvider(email, "normal");
 
         if (optionalUser.isPresent()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");

--- a/src/test/java/com/plac/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/plac/repository/RefreshTokenRepositoryTest.java
@@ -74,7 +74,6 @@ class RefreshTokenRepositoryTest {
                 .username(username)
                 .password("password1234")
                 .roles("ROLE_USER")
-                .createdAt(LocalDateTime.now())
                 .build();
         userRepository.save(buildUser);
 

--- a/src/test/java/com/plac/repository/UserRepositoryTest.java
+++ b/src/test/java/com/plac/repository/UserRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.plac.repository;
 
 import com.plac.domain.User;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -10,7 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -35,7 +36,6 @@ public class UserRepositoryTest {
                 .username("test1@email.com")
                 .password("password1234")
                 .roles("ROLE_USER")
-                .createdAt(LocalDateTime.now())
                 .build();
         userRepository.save(buildUser);
     }
@@ -48,7 +48,6 @@ public class UserRepositoryTest {
                 .username("test2@email.com")
                 .password("password1234")
                 .roles("ROLE_USER")
-                .createdAt(LocalDateTime.now())
                 .build();
         userRepository.save(testUser);
 
@@ -81,7 +80,6 @@ public class UserRepositoryTest {
                 .username("naver_user@email.com")
                 .password("password1234")
                 .roles("ROLE_USER")
-                .createdAt(LocalDateTime.now())
                 .build();
         userRepository.save(testUser);
 

--- a/src/test/java/com/plac/service/email/EmailVerificationServiceTest.java
+++ b/src/test/java/com/plac/service/email/EmailVerificationServiceTest.java
@@ -45,7 +45,6 @@ public class EmailVerificationServiceTest {
                 .password("password")
                 .provider("normal")
                 .roles("ROLE_USER")
-                .createdAt(LocalDateTime.now())
                 .build();
         userRepository.save(user); // userId = 1L;
     }

--- a/src/test/java/com/plac/service/social_login/SocialLoginServiceImplTest.java
+++ b/src/test/java/com/plac/service/social_login/SocialLoginServiceImplTest.java
@@ -98,7 +98,6 @@ class SocialLoginServiceImplTest {
         return User.builder()
                 .provider("google")
                 .username("user1@email.com")
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/test/java/com/plac/service/social_login/SpySocialLoginServiceImpl.java
+++ b/src/test/java/com/plac/service/social_login/SpySocialLoginServiceImpl.java
@@ -5,15 +5,12 @@ import com.plac.domain.social_login.Oauth2UserInfo;
 import com.plac.dto.request.social_login.SocialLoginReqDto;
 import com.plac.dto.response.social_login.Oauth2TokenResDto;
 import com.plac.dto.response.social_login.SocialLoginResDto;
-import com.plac.repository.RefreshTokenRepository;
 import com.plac.repository.UserRepository;
 import com.plac.service.social_login.provider.token.TokenProviderContext;
 import com.plac.service.social_login.provider.user_info.Oauth2UserInfoContext;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -51,8 +48,6 @@ public class SpySocialLoginServiceImpl implements SocialLoginService{
                 .password(password)
                 .roles("ROLE_USER")
                 .provider(oauth2UserInfo.getProvider())
-                .profileImagePath(oauth2UserInfo.getProfileImagePath())
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/test/java/com/plac/service/user/UserServiceImplTest.java
+++ b/src/test/java/com/plac/service/user/UserServiceImplTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +48,6 @@ class UserServiceImplTest {
                 .username("test1@email.com")
                 .provider("normal")
                 .roles("ROLE_USER")
-                .createdAt(LocalDateTime.now())
                 .build();
 
         mockUserList = Arrays.asList(
@@ -57,13 +55,11 @@ class UserServiceImplTest {
                         .username("test2@example.com")
                         .provider("google")
                         .roles("ROLE_USER")
-                        .createdAt(LocalDateTime.now())
                         .build(),
                 User.builder()
                         .username("test3@example.com")
                         .provider("kakao")
                         .roles("ROLE_USER")
-                        .createdAt(LocalDateTime.now())
                         .build()
         );
     }


### PR DESCRIPTION
### 관련 이슈 
#### #21

<br>

###  구현 목록
#### ✅ 카카오맵 API의 장소를 PLAC 서버의 장소로 매핑
#### ✅ 세부 장소 조회 기능
#### ✅ 각 장소에 리뷰와 태그, 별점을 부여하는 기능
#### ⚠️ 필터 별 리뷰 페이지네이션
- 총 4개의 필터 (최신순, 평점 내림차순, 평점 올림차순, 공감순) 중 최신순 필터만 구현
- 추후 보완 필요

