### PR TITLE
[FEAT] .gitignore 설정에서 Dockerfile 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-### Dockerfile ###
-Dockerfile


### PR DESCRIPTION
깃허브 액션에서 도커 이미지 빌드를 위해서 Dockerfile 필요