### PR TITLE
[FEAT/50] 마이리스트 찜 플랜 조회 API 추가

### DIFF
--- a/src/main/java/com/plac/domain/email_verification/service/EmailService.java
+++ b/src/main/java/com/plac/domain/email_verification/service/EmailService.java
@@ -1,7 +1,6 @@
 package com.plac.domain.email_verification.service;
 
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -15,11 +14,14 @@ import javax.mail.internet.MimeMessage;
 @Log4j2
 public class EmailService {
 
-    @Autowired
-    private JavaMailSender emailSender;
-
     @Value("${spring.mail.username}")
     private String senderEmail;
+
+    private final JavaMailSender emailSender;
+
+    public EmailService(JavaMailSender emailSender) {
+        this.emailSender = emailSender;
+    }
 
     public void sendSimpleMessage(String to, String subject, String text) {
         MimeMessage message = emailSender.createMimeMessage();

--- a/src/main/java/com/plac/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/plac/domain/place/controller/PlaceController.java
@@ -31,13 +31,13 @@ public class PlaceController {
     }
 
     @PostMapping("/my-list")
-    public ResponseEntity<?> addMyListDibsPlace(KakaoPlaceInfo request) {
+    public ResponseEntity<Void> addMyListDibsPlace(KakaoPlaceInfo request) {
         placeService.triggerDibsMyListPlace(request);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/my-list")
-    public ResponseEntity<?> deleteMyListDibsPlace(Long kakaoPlaceId) {
+    @DeleteMapping("/my-list/{kakaoPlaceId}")
+    public ResponseEntity<Void> deleteMyListDibsPlace(@PathVariable Long kakaoPlaceId) {
         placeService.deleteMyListPlace(kakaoPlaceId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/plac/domain/place/repository/place/PlaceQueryRepositoryImpl.java
+++ b/src/main/java/com/plac/domain/place/repository/place/PlaceQueryRepositoryImpl.java
@@ -23,7 +23,6 @@ public class PlaceQueryRepositoryImpl implements PlaceQueryRepository {
         return jpaQueryFactory.selectFrom(place)
                 .leftJoin(placeDibs)
                 .on(place.kakaoPlaceId.eq(placeDibs.kakaoPlaceId))
-                //.fetchJoin()
                 .where(placeDibs.userId.eq(userId))
                 .orderBy(place.placeName.asc())
                 .fetch();

--- a/src/main/java/com/plac/domain/place/service/PlaceService.java
+++ b/src/main/java/com/plac/domain/place/service/PlaceService.java
@@ -26,6 +26,7 @@ public class PlaceService {
     private final PlaceDibsRepository placeDibsRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public List<GetMyListPlacesResponseDto> getMyListPlaces() {
         final User user = userRepository.findById(SecurityContextHolderUtil.getUserId())
                 .orElseThrow(() -> new RuntimeException("로그인 사용자 없음 예외추가"));

--- a/src/main/java/com/plac/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/plac/domain/plan/controller/PlanController.java
@@ -85,10 +85,15 @@ public class PlanController {
         return ResponseEntity.ok().body(result);
     }
 
-
     @GetMapping("/most-favorites")
     public ResponseEntity<?> getMostPopularPlans(){
         List<PlansInformation> result = planService.getMostPopularPlans();
         return ResponseEntity.ok().body(result);
+    }
+
+    @PostMapping("/{planId}/my-list")
+    public ResponseEntity<Void> addMyListDibsPlan(@PathVariable Long planId) {
+        planService.triggerDibsMyListPlan(planId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/plac/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/plac/domain/plan/controller/PlanController.java
@@ -3,6 +3,7 @@ package com.plac.domain.plan.controller;
 import com.plac.domain.plan.dto.request.PlanCreateRequest;
 import com.plac.domain.plan.dto.request.PlanFixRequest;
 import com.plac.domain.plan.dto.request.PlanShareRequest;
+import com.plac.domain.plan.dto.response.GetMyListPlansResponseDto;
 import com.plac.domain.plan.dto.response.PlanCreateResponse;
 import com.plac.domain.plan.dto.response.PlansInformation;
 import com.plac.domain.plan.service.PlanService;
@@ -95,5 +96,11 @@ public class PlanController {
     public ResponseEntity<Void> addMyListDibsPlan(@PathVariable Long planId) {
         planService.triggerDibsMyListPlan(planId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/my-list")
+    public ResponseEntity<List<GetMyListPlansResponseDto>> getMyListDibsPlan() {
+        List<GetMyListPlansResponseDto> getPlans = planService.getMyListPlans();
+        return ResponseEntity.ok(getPlans);
     }
 }

--- a/src/main/java/com/plac/domain/plan/dto/response/GetMyListPlansResponseDto.java
+++ b/src/main/java/com/plac/domain/plan/dto/response/GetMyListPlansResponseDto.java
@@ -1,0 +1,31 @@
+package com.plac.domain.plan.dto.response;
+
+import com.plac.domain.plan.entity.Plan;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetMyListPlansResponseDto {
+    private String userProfileName;
+    private Long planId;
+    private String planName;
+    private String destinationName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<String> placeImagesUrls;
+
+    public GetMyListPlansResponseDto(String userProfileName, Plan plan, List<String> placeImagesUrls) {
+        this.userProfileName = userProfileName;
+        this.planId = plan.getId();
+        this.planName = plan.getName();
+        this.destinationName = plan.getDestinationName();
+        this.createdAt = plan.getCreatedAt();
+        this.updatedAt = plan.getUpdatedAt();
+        this.placeImagesUrls = placeImagesUrls;
+    }
+}

--- a/src/main/java/com/plac/domain/plan/entity/PlanDibs.java
+++ b/src/main/java/com/plac/domain/plan/entity/PlanDibs.java
@@ -1,0 +1,43 @@
+package com.plac.domain.plan.entity;
+
+import com.plac.common.AbstractTimeEntity;
+import com.plac.domain.place.entity.PlaceDibs;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanDibs extends AbstractTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long planId;
+
+    @NotNull
+    private Long userId;
+
+    @Builder
+    public PlanDibs(Long planId, Long userId) {
+        this.planId = planId;
+        this.userId = userId;
+    }
+
+    public static PlanDibs create(Long planId, Long userId) {
+        return PlanDibs.builder()
+                .planId(planId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/plac/domain/plan/repository/plan/PlanQueryRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/plan/PlanQueryRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface PlanQueryRepository {
 
     List<Plan> findPlansByDestinationName(String destinationName);
+
+    List<Plan> findPlanDibsByUserId(Long userId);
 }

--- a/src/main/java/com/plac/domain/plan/repository/plan/PlanQueryRepositoryImpl.java
+++ b/src/main/java/com/plac/domain/plan/repository/plan/PlanQueryRepositoryImpl.java
@@ -1,13 +1,13 @@
 package com.plac.domain.plan.repository.plan;
 
 import com.plac.domain.plan.entity.Plan;
-import com.plac.domain.plan.entity.QPlan;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 import static com.plac.domain.plan.entity.QPlan.plan;
+import static com.plac.domain.plan.entity.QPlanDibs.planDibs;
 
 @Repository
 public class PlanQueryRepositoryImpl implements PlanQueryRepository {
@@ -22,6 +22,16 @@ public class PlanQueryRepositoryImpl implements PlanQueryRepository {
     public List<Plan> findPlansByDestinationName(String destinationName) {
         return jpaQueryFactory.selectFrom(plan)
                 .where(plan.destinationName.eq(destinationName))
+                .fetch();
+    }
+
+    @Override
+    public List<Plan> findPlanDibsByUserId(Long userId) {
+        return jpaQueryFactory.selectFrom(plan)
+                .leftJoin(planDibs)
+                .on((plan.id.eq(planDibs.planId)))
+                .where(planDibs.userId.eq(userId))
+                .orderBy(planDibs.createdAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDIbsRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDIbsRepository.java
@@ -1,0 +1,7 @@
+package com.plac.domain.plan.repository.planDibs;
+
+import com.plac.domain.plan.entity.PlanDibs;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanDIbsRepository extends JpaRepository<PlanDibs, Long>, PlanDibsQueryRepository {
+}

--- a/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepository.java
@@ -1,4 +1,10 @@
 package com.plac.domain.plan.repository.planDibs;
 
+import com.plac.domain.plan.entity.PlanDibs;
+
+import java.util.Optional;
+
 public interface PlanDibsQueryRepository {
+
+    Optional<PlanDibs> findDibsByUserIdAndPlanId(Long userId, Long planId);
 }

--- a/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepository.java
@@ -1,0 +1,4 @@
+package com.plac.domain.plan.repository.planDibs;
+
+public interface PlanDibsQueryRepository {
+}

--- a/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImpl.java
+++ b/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImpl.java
@@ -1,7 +1,29 @@
 package com.plac.domain.plan.repository.planDibs;
 
+import com.plac.domain.plan.entity.PlanDibs;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.plac.domain.plan.entity.QPlanDibs.planDibs;
 
 @Repository
 public class PlanDibsQueryRepositoryImpl implements PlanDibsQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public PlanDibsQueryRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Optional<PlanDibs> findDibsByUserIdAndPlanId(Long userId, Long planId) {
+        return Optional.ofNullable(
+                jpaQueryFactory.selectFrom(planDibs)
+                        .where(planDibs.planId.eq(planId)
+                                .and(planDibs.userId.eq(userId)))
+                        .fetchOne()
+        );
+    }
 }

--- a/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImpl.java
+++ b/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImpl.java
@@ -1,0 +1,7 @@
+package com.plac.domain.plan.repository.planDibs;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PlanDibsQueryRepositoryImpl implements PlanDibsQueryRepository {
+}

--- a/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/planDibs/PlanDibsRepository.java
@@ -3,5 +3,5 @@ package com.plac.domain.plan.repository.planDibs;
 import com.plac.domain.plan.entity.PlanDibs;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlanDIbsRepository extends JpaRepository<PlanDibs, Long>, PlanDibsQueryRepository {
+public interface PlanDibsRepository extends JpaRepository<PlanDibs, Long>, PlanDibsQueryRepository {
 }

--- a/src/main/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceMappingRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceMappingRepository.java
@@ -3,5 +3,5 @@ package com.plac.domain.plan.repository.planPlaceMapping;
 import com.plac.domain.plan.entity.PlanPlaceMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlanPlaceMappingMappingRepository extends JpaRepository<PlanPlaceMapping, Long>, PlanPlaceQueryMappingRepository {
+public interface PlanPlaceMappingRepository extends JpaRepository<PlanPlaceMapping, Long>, PlanPlaceQueryMappingRepository {
 }

--- a/src/main/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceQueryMappingRepository.java
+++ b/src/main/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceQueryMappingRepository.java
@@ -1,5 +1,6 @@
 package com.plac.domain.plan.repository.planPlaceMapping;
 
+import com.plac.domain.place.entity.Place;
 import com.plac.domain.plan.entity.PlanPlaceMapping;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface PlanPlaceQueryMappingRepository {
 
     List<PlanPlaceMapping> findByPlanId(Long planId);
+
+    List<Place> findPlacesByPlanId(Long planId);
 }

--- a/src/main/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceQueryMappingRepositoryImpl.java
+++ b/src/main/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceQueryMappingRepositoryImpl.java
@@ -1,11 +1,14 @@
 package com.plac.domain.plan.repository.planPlaceMapping;
 
+import com.plac.domain.place.entity.Place;
+import com.plac.domain.place.entity.QPlace;
 import com.plac.domain.plan.entity.PlanPlaceMapping;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.plac.domain.place.entity.QPlace.place;
 import static com.plac.domain.plan.entity.QPlanPlaceMapping.planPlaceMapping;
 
 @Repository
@@ -21,6 +24,14 @@ public class PlanPlaceQueryMappingRepositoryImpl implements PlanPlaceQueryMappin
     public List<PlanPlaceMapping> findByPlanId(Long planId) {
         return jpaQueryFactory.selectFrom(planPlaceMapping)
                 .where(planPlaceMapping.plan.id.eq(planId))
+                .fetch();
+    }
+
+    @Override
+    public List<Place> findPlacesByPlanId(Long planId) {
+        return jpaQueryFactory.selectFrom(place)
+                .leftJoin(planPlaceMapping)
+                .on(planPlaceMapping.place.id.eq(planId))
                 .fetch();
     }
 }

--- a/src/test/java/com/plac/domain/place/repository/place/PlaceQueryRepositoryImplTest.java
+++ b/src/test/java/com/plac/domain/place/repository/place/PlaceQueryRepositoryImplTest.java
@@ -8,6 +8,8 @@ import com.plac.domain.place.dto.response.GetMyListPlacesResponseDto;
 import com.plac.domain.place.entity.Place;
 import com.plac.domain.place.entity.PlaceDibs;
 import com.plac.domain.place.repository.placeDibs.PlaceDibsRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -37,7 +39,8 @@ class PlaceQueryRepositoryImplTest {
     private PlaceRepository placeRepository;
 
     @Test
-    void test()  {
+    @DisplayName("마이리스트에 장소 찜한다.")
+    void addMyListPlace()  {
         // given
         List<Place> places = new ArrayList<>();
         for (int i = 0; i < 10; i++) {

--- a/src/test/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImplTest.java
+++ b/src/test/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImplTest.java
@@ -5,13 +5,15 @@ import com.plac.domain.plan.entity.Plan;
 import com.plac.domain.plan.entity.PlanDibs;
 import com.plac.domain.plan.repository.plan.PlanRepository;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         PlanDibsQueryRepositoryImpl.class,
         TestQueryDSLConfiguration.class
 })
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PlanDibsQueryRepositoryImplTest {
 
@@ -31,6 +34,7 @@ class PlanDibsQueryRepositoryImplTest {
     private PlanRepository planRepository;
 
     @Test
+    @Order(0)
     @DisplayName("마이리스트에 플랜 찜한다.")
     void addMyListPlan() {
         // given
@@ -50,5 +54,48 @@ class PlanDibsQueryRepositoryImplTest {
         // then
         assertThat(result.getPlanId()).isEqualTo(1L);
         assertThat(result.getUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("마이리스트에 찜 플랜 가져온다.")
+    void getMyListPlans() {
+        // given
+        List<Plan> plans = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Plan plan = Plan.builder()
+                    .name("test-place-name " + (i + 1))
+                    .destinationName("test-destinationName")
+                    .build();
+            plans.add(plan);
+        }
+        planRepository.saveAll(plans);
+
+        long userId = 2L;
+        long userId2 = 3L;
+
+        List<PlanDibs> user1Dibs = new ArrayList<>();
+        for (int i = 0; i < plans.size(); i++) {
+            long planId = (long) (i + 2);
+            PlanDibs planDibs = PlanDibs.create(planId, userId);
+            user1Dibs.add(planDibs);
+        }
+        planDibsRepository.saveAll(user1Dibs);
+
+        List<PlanDibs> user2Dibs = new ArrayList<>();
+        for (int i = 2; i < 6; i++) {
+            long planId = (long) (i + 2);
+            PlanDibs planDibs = PlanDibs.create(planId, userId2);
+            user2Dibs.add(planDibs);
+        }
+        planDibsRepository.saveAll(user2Dibs);
+
+        // when
+        List<Plan> userId1Dibs = planRepository.findPlanDibsByUserId(userId);
+        List<Plan> userId2Dibs = planRepository.findPlanDibsByUserId(userId2);
+
+        // then
+        assertThat(userId1Dibs).hasSize(10);
+        assertThat(userId2Dibs).hasSize(4);
     }
 }

--- a/src/test/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImplTest.java
+++ b/src/test/java/com/plac/domain/plan/repository/planDibs/PlanDibsQueryRepositoryImplTest.java
@@ -1,0 +1,54 @@
+package com.plac.domain.plan.repository.planDibs;
+
+import com.config.TestQueryDSLConfiguration;
+import com.plac.domain.plan.entity.Plan;
+import com.plac.domain.plan.entity.PlanDibs;
+import com.plac.domain.plan.repository.plan.PlanRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({
+        PlanDibsQueryRepositoryImpl.class,
+        TestQueryDSLConfiguration.class
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PlanDibsQueryRepositoryImplTest {
+
+    @Autowired
+    private PlanDibsRepository planDibsRepository;
+
+    @Autowired
+    private PlanRepository planRepository;
+
+    @Test
+    @DisplayName("마이리스트에 플랜 찜한다.")
+    void addMyListPlan() {
+        // given
+        Plan p = Plan.builder()
+                .name("test-plan-name")
+                .destinationName("test-plan-destinationName")
+                .build();
+
+        Plan plan = planRepository.save(p);
+
+        long userId = 1L;
+        PlanDibs planDibs = PlanDibs.create(plan.getId(), userId);
+
+        // when
+        PlanDibs result = planDibsRepository.save(planDibs);
+
+        // then
+        assertThat(result.getPlanId()).isEqualTo(1L);
+        assertThat(result.getUserId()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceMappingRepositoryTest.java
+++ b/src/test/java/com/plac/domain/plan/repository/planPlaceMapping/PlanPlaceMappingRepositoryTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PlanPlaceMappingRepositoryTest {
 
     @Autowired
-    private PlanPlaceMappingMappingRepository planPlaceMappingRepository;
+    private PlanPlaceMappingRepository planPlaceMappingRepository;
 
     @Autowired
     private PlanRepository planRepository;

--- a/src/test/java/com/plac/domain/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/plac/domain/plan/service/PlanServiceTest.java
@@ -8,7 +8,7 @@ import com.plac.domain.place.repository.place.PlaceRepository;
 import com.plac.domain.plan.dto.request.PlanCreateRequest;
 import com.plac.domain.plan.dto.response.PlanCreateResponse;
 import com.plac.domain.plan.entity.PlanPlaceMapping;
-import com.plac.domain.plan.repository.planPlaceMapping.PlanPlaceMappingMappingRepository;
+import com.plac.domain.plan.repository.planPlaceMapping.PlanPlaceMappingRepository;
 import com.plac.domain.plan.repository.plan.PlanRepository;
 import com.plac.domain.user.dto.request.CreateUserRequest;
 import com.plac.domain.user.entity.User;
@@ -51,7 +51,7 @@ class PlanServiceTest {
     private PlanRepository planRepository;
 
     @Autowired
-    private PlanPlaceMappingMappingRepository planPlaceMappingRepository;
+    private PlanPlaceMappingRepository planPlaceMappingRepository;
 
     @Autowired
     private AuthenticationManager authenticationManager;


### PR DESCRIPTION
## PR
마이리스트에서 찜한 플랜들을 가져오는 작업을 진행했습니다.

## 작업 내용
- [x] 마이리스트 찜 플랜 조회 서비스, API 추가
- [x] 몇 가지 리팩토링
- [x] 테스트 코드 작성

## 전달 사항
응답 형식
``` json
{
   {
     "userProfileName": "Jinseo Choi",
     "planId": 0,
     "planName": "성수동 데이트 코스",
     "destinationName": "성수동",
     "createdAt": "2023-02-10T14:30:00Z",
     "updatedAt" : "~",
     "placeImagesUrls": [
	   "image-link1",
	   "image -link2",
            .....
        ]
   }
}
```
close #50 
